### PR TITLE
Fix update-profile to exit properly on success

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func main() {
 				Name:        "update-profile",
 				Description: "Update profile",
 				Usage:       "Update profile",
-				UsageText:   "bsky update-profile",
+				UsageText:   "bsky update-profile [display name] [description]",
 				Flags: []cli.Flag{
 					&cli.StringFlag{Name: "avatar", Value: "", Usage: "avatar image", TakesFile: true},
 					&cli.StringFlag{Name: "banner", Value: "", Usage: "banner image", TakesFile: true},

--- a/profile.go
+++ b/profile.go
@@ -105,7 +105,10 @@ func doUpdateProfile(cCtx *cli.Context) error {
 		Avatar:      avatar,
 		Banner:      banner,
 	})
-	return fmt.Errorf("cannot update profile: %w", err)
+	if err != nil {
+		return fmt.Errorf("cannot update profile: %w", err)
+	}
+	return nil
 }
 
 func doFollow(cCtx *cli.Context) error {


### PR DESCRIPTION
The subcommand was working correctly, but it always printed an error message (`cannot update profile: %!w(<nil>)`) and exited with a non-zero code. This patch fixes it.