### PR TITLE
make update-profile update-able only images without texts

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func main() {
 				Name:        "update-profile",
 				Description: "Update profile",
 				Usage:       "Update profile",
-				UsageText:   "bsky update-profile [display name] [description]",
+				UsageText:   "bsky update-profile [OPTIONS]... [{display name} [description]]",
 				Flags: []cli.Flag{
 					&cli.StringFlag{Name: "avatar", Value: "", Usage: "avatar image", TakesFile: true},
 					&cli.StringFlag{Name: "banner", Value: "", Usage: "banner image", TakesFile: true},

--- a/profile.go
+++ b/profile.go
@@ -55,7 +55,28 @@ func doShowProfile(cCtx *cli.Context) error {
 }
 
 func doUpdateProfile(cCtx *cli.Context) error {
-	if cCtx.Args().Len() != 2 {
+	// read arguments
+	var name *string
+	if cCtx.Args().Len() >= 1 {
+		v := cCtx.Args().Get(0)
+		name = &v
+	}
+	var desc *string
+	if cCtx.Args().Len() >= 2 {
+		v := cCtx.Args().Get(1)
+		desc = &v
+	}
+	// read optionns
+	var avatarFn *string
+	if s := cCtx.String("avatar"); s != "" {
+		avatarFn = &s
+	}
+	var bannerFn *string
+	if s := cCtx.String("banner"); s != "" {
+		bannerFn = &s
+	}
+
+	if name == nil && desc == nil && avatarFn == nil && bannerFn == nil {
 		return cli.ShowSubcommandHelp(cCtx)
 	}
 
@@ -63,13 +84,10 @@ func doUpdateProfile(cCtx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("cannot create client: %w", err)
 	}
-	name := cCtx.Args().Get(0)
-	desc := cCtx.Args().Get(1)
 
 	var avatar *lexutil.Blob
-	avatarFn := cCtx.String("avatar")
-	if avatarFn != "" {
-		b, err := os.ReadFile(avatarFn)
+	if avatarFn != nil {
+		b, err := os.ReadFile(*avatarFn)
 		if err != nil {
 			return fmt.Errorf("cannot read image file: %w", err)
 		}
@@ -83,9 +101,8 @@ func doUpdateProfile(cCtx *cli.Context) error {
 		}
 	}
 	var banner *lexutil.Blob
-	bannerFn := cCtx.String("banner")
-	if bannerFn != "" {
-		b, err := os.ReadFile(bannerFn)
+	if bannerFn != nil {
+		b, err := os.ReadFile(*bannerFn)
 		if err != nil {
 			return fmt.Errorf("cannot read image file: %w", err)
 		}
@@ -100,8 +117,8 @@ func doUpdateProfile(cCtx *cli.Context) error {
 	}
 
 	_, err = bsky.ActorUpdateProfile(context.TODO(), xrpcc, &bsky.ActorUpdateProfile_Input{
-		Description: &desc,
-		DisplayName: &name,
+		Description: desc,
+		DisplayName: name,
 		Avatar:      avatar,
 		Banner:      banner,
 	})


### PR DESCRIPTION
`update-profile` が画像(avatarやbanner)だけ更新できなかったので、できるようにしました。
(常にdispace nameとdescriptionもセットで指定しなければならなかった)


もともと2個の引数が必須だったのを、
0個または1個を許容するようにし1個のみの時はdisplay nameとして解釈します。
それに合わせてサブコマンドの使い方説明を変更しました。

変更前: `[display name] [description]`
変更後: `[{display name} [description]]`