### PR TITLE
Add -image-alt flag to post alt text

### DIFF
--- a/main.go
+++ b/main.go
@@ -112,6 +112,7 @@ func main() {
 					&cli.StringFlag{Name: "q"},
 					&cli.BoolFlag{Name: "stdin"},
 					&cli.StringSliceFlag{Name: "image", Aliases: []string{"i"}},
+					&cli.StringSliceFlag{Name: "image-alt", Aliases: []string{"ia"}},
 				},
 				HelpName:  "post",
 				ArgsUsage: "[text]",

--- a/timeline.go
+++ b/timeline.go
@@ -341,9 +341,10 @@ func doPost(cCtx *cli.Context) error {
 
 	// embeded images
 	imageFn := cCtx.StringSlice("image")
+	imageAltFn := cCtx.StringSlice("image-alt")
 	if len(imageFn) > 0 {
 		var images []*bsky.EmbedImages_Image
-		for _, fn := range imageFn {
+		for i, fn := range imageFn {
 			b, err := os.ReadFile(fn)
 			if err != nil {
 				return fmt.Errorf("cannot read image file: %w", err)
@@ -352,8 +353,14 @@ func doPost(cCtx *cli.Context) error {
 			if err != nil {
 				return fmt.Errorf("cannot upload image file: %w", err)
 			}
+			var alt string
+			if len(imageAltFn) < i {
+				alt = filepath.Base(fn)
+			} else {
+				alt = imageAltFn[i]
+			}
 			images = append(images, &bsky.EmbedImages_Image{
-				Alt: filepath.Base(fn),
+				Alt: alt,
 				Image: &lexutil.LexBlob{
 					Ref:      resp.Blob.Ref,
 					MimeType: http.DetectContentType(b),


### PR DESCRIPTION
Hey, I came here because I noticed that [bskybots](https://github.com/QuietImCoding/bskybots) uses your library for the meme bot but the alt text is just a filename. Here’s a prototype that adds an `-image-alt` flag to override the filename. You can see it successfully worked [here](https://staging.bsky.app/profile/buck.aboli.sh/post/3jurnrqmosk2m).

There’s at least one problem I’m aware of, if you ran something like this:

```
bsky post -image i1.png -image-alt "image description 1" -image i2.png -image i3.png -image-alt "image description 3" "some images"
```

This implementation would miss the alt text for the third image. I looked at the [urfave/cli](https://github.com/urfave/cli) documentation and couldn’t find anything about pairing flags but I’m barely familiar with Go and could have missed something.

Thanks for all the work on this! 🤩