### PR TITLE
Add cursor argument to stream for backfill

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,6 +84,7 @@ func main() {
 				Usage:       "Show timeline as stream",
 				UsageText:   "bsky stream",
 				Flags: []cli.Flag{
+					&cli.StringFlag{Name: "cursor", Value: "", Usage: "cursor"},
 					&cli.StringFlag{Name: "handle", Aliases: []string{"H"}, Value: "", Usage: "user handle"},
 					&cli.StringFlag{Name: "pattern", Usage: "pattern"},
 					&cli.StringFlag{Name: "reply", Usage: "reply"},

--- a/timeline.go
+++ b/timeline.go
@@ -601,6 +601,10 @@ func doStream(cCtx *cli.Context) error {
 		}
 		u.Scheme = "wss"
 		u.Path = "/xrpc/com.atproto.sync.subscribeRepos"
+		cur := cCtx.String("cursor")
+		if cur != "" {
+			u.RawQuery = "cursor=" + cur
+		}
 		host = u.String()
 	}
 	pattern := cCtx.String("pattern")


### PR DESCRIPTION
In case of stream interruption, there's a cursor argument to get events you missed. Just plug in the last seq you received.