### PR TITLE
Post a message successfully even if bsky fails to get thumbnail of link card

### DIFF
--- a/timeline.go
+++ b/timeline.go
@@ -218,7 +218,7 @@ func addLink(xrpcc *xrpc.Client, post *bsky.FeedPost, link string) {
 	}
 	if imgURL != "" && post.Embed.EmbedExternal != nil {
 		resp, err := http.Get(imgURL)
-		if err == nil {
+		if err == nil && resp.StatusCode == http.StatusOK {
 			defer resp.Body.Close()
 			b, err := io.ReadAll(resp.Body)
 			if err == nil {


### PR DESCRIPTION
When the og:image URL returns a status code other than 200, as in the case of https://www.mof.go.jp/index.htm, bsky is unable to post the message.
```
$ bsky post https://www.mof.go.jp/index.htm
failed to create post: XRPC ERROR 400: InvalidMimeType: Referenced Mimetype does not match stored blob. Expected: */*, Got: text/plain; charset=utf-8
```
In such instances, bsky should bypass to embed the og:image and proceed to post the message successfully.