### PR TITLE
Add test for `extractTags`

### DIFF
--- a/extract_test.go
+++ b/extract_test.go
@@ -47,3 +47,28 @@ func TestExtractMentions(t *testing.T) {
 		}
 	}
 }
+
+func TestExtractTags(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []entry
+	}{
+		{name: "1", input: `Hi, #Bluesky!`, want: []entry{{text: "Bluesky!", start: 4, end: 13}}},
+		{name: "2", input: `bsky から#テスト`, want: []entry{{text: "テスト", start: 7, end: 11}}},
+		{name: "3", input: `Emoji hashtags: #🦋 #🟦🈳 #🌌`, want: []entry{
+			{text: "🦋", start: 16, end: 18},
+			{text: "🟦🈳", start: 19, end: 22},
+			{text: "🌌", start: 23, end: 25},
+		}},
+	}
+	for _, test := range tests {
+		result := extractTags(test.input)
+		if len(result) != len(test.want) {
+			t.Fatalf("extract %d tag(s)", len(test.want))
+		}
+		if !reflect.DeepEqual(result, test.want) {
+			t.Fatalf("want %v but got %v for test %v", test.want, result, test.name)
+		}
+	}
+}


### PR DESCRIPTION

Hi, I'm reading the code in this repository to understand the mechanism of hashtag extraction.

It was very clear and helpful, but to deepen my understanding, I added a simple test.
Currently, it seems there are no tests yet, so if it proves useful, please consider merging it.

Thanks!