### PR TITLE
The follow subcommand should be able to read a list of accounts from a YAML file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bsky.exe
 tmp
 *.sh
 .DS_Store
+.idea/**

--- a/follow.go
+++ b/follow.go
@@ -1,0 +1,12 @@
+package main
+
+// FollowList is a data structure to hold a list of folks to follow
+type FollowList struct {
+	APIVersion string    `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string    `json:"kind" yaml:"kind"`
+	Accounts   []Account `json:"accounts" yaml:"accounts"`
+}
+
+type Account struct {
+	Handle string `json:"handle" yaml:"handle"`
+}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,9 @@ require (
 	github.com/fatih/color v1.16.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/ipfs/go-cid v0.4.1
+	github.com/pkg/errors v0.9.1
 	github.com/urfave/cli/v2 v2.27.2
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require github.com/orandin/slog-gorm v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -255,6 +255,8 @@ github.com/orandin/slog-gorm v1.3.2/go.mod h1:MoZ51+b7xE9lwGNPYEhxcUtRNrYzjdcKvA
 github.com/petar/GoLLRB v0.0.0-20210522233825-ae3b015fd3e9 h1:1/WtZae0yGtPq+TI6+Tv1WTxkukpXeMlviSxvL7SRgk=
 github.com/petar/GoLLRB v0.0.0-20210522233825-ae3b015fd3e9/go.mod h1:x3N5drFsm2uilKKuuYo6LdyD8vZAW55sH/9w+pbo1sw=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/polydawn/refmt v0.89.1-0.20221221234430-40501e09de1f h1:VXTQfuJj9vKR4TCkEuWIckKvdHFeJH/huIFJ9/cXOB0=

--- a/main.go
+++ b/main.go
@@ -170,6 +170,9 @@ func main() {
 				UsageText:   "bsky follow [handle]",
 				HelpName:    "follow",
 				Action:      doFollow,
+				Flags: []cli.Flag{
+					&cli.StringFlag{Name: "file", Aliases: []string{"f"}, Value: "", Usage: "-f Path to a YAML file containing a FollowList of accounts to follow."},
+				},
 			},
 			{
 				Name:        "unfollow",


### PR DESCRIPTION
* This makes it easy to collaboratively maintain lists of accounts to follow
* Right now bluesky supports starter packs but there's no easy way to collaborate on them
* With this PR folks can collaborate using a YAML file in git
* They can then just use the CLI to follow them.
* CLI supports reading directly from a URL so a user can do something like

   ```
   bsky follow -f https://raw.githubusercontent.com/jlewi/bskylists/refs/heads/main/aiengineering.yaml
   ```