### PR TITLE
Add autocomplete support for CLI in Bash, Zsh, and PowerShell

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,33 @@ Or install with go install command.
 go install github.com/mattn/bsky@latest
 ```
 
+### To enable Autocomplete
+
+Download the correct file from `/scripts` directory and add the following line to your shell configuration file.
+
+ZSH:
+```sh
+# Add the following line to your .zshrc
+source /path/to/autocomplete.zsh
+```
+
+Bash:
+```bash
+# Add the following line to your .bashrc
+source /path/to/autocomplete.sh
+```
+
+PowerShell:
+```powershell
+# Add the following line to your $PROFILE
+/path/to/autocomplete.ps1
+```
+
+
+## Development
+
+```
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -87,11 +87,6 @@ PowerShell:
 /path/to/autocomplete.ps1
 ```
 
-
-## Development
-
-```
-
 ## License
 
 MIT

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ func main() {
 		Usage:       name,
 		Version:     version,
 		Description: "A cli application for bluesky",
+		EnableBashCompletion: true,
 		Flags: []cli.Flag{
 			&cli.StringFlag{Name: "a", Usage: "profile name"},
 			&cli.BoolFlag{Name: "V", Usage: "verbose"},

--- a/scripts/autocomplete.sh
+++ b/scripts/autocomplete.sh
@@ -1,0 +1,35 @@
+#! /bin/bash
+
+: ${PROG:=$(basename ${BASH_SOURCE})}
+
+# Macs have bash3 for which the bash-completion package doesn't include
+# _init_completion. This is a minimal version of that function.
+_cli_init_completion() {
+  COMPREPLY=()
+  _get_comp_words_by_ref "$@" cur prev words cword
+}
+
+_cli_bash_autocomplete() {
+  if [[ "${COMP_WORDS[0]}" != "source" ]]; then
+    local cur opts base words
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    if declare -F _init_completion >/dev/null 2>&1; then
+      _init_completion -n "=:" || return
+    else
+      _cli_init_completion -n "=:" || return
+    fi
+    words=("${words[@]:0:$cword}")
+    if [[ "$cur" == "-"* ]]; then
+      requestComp="${words[*]} ${cur} --generate-shell-completion"
+    else
+      requestComp="${words[*]} --generate-shell-completion"
+    fi
+    opts=$(eval "${requestComp}" 2>/dev/null)
+    COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+    return 0
+  fi
+}
+
+complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete $PROG
+unset PROG

--- a/scripts/autocomplete.zsh
+++ b/scripts/autocomplete.zsh
@@ -1,0 +1,23 @@
+compdef _bsky bsky
+
+_bsky() {
+	local -a opts
+	local cur
+	cur=${words[-1]}
+	if [[ "$cur" == "-"* ]]; then
+		opts=("${(@f)$(${words[@]:0:#words[@]-1} ${cur} --generate-shell-completion)}")
+	else
+		opts=("${(@f)$(${words[@]:0:#words[@]-1} --generate-shell-completion)}")
+	fi
+
+	if [[ "${opts[1]}" != "" ]]; then
+		_describe 'values' opts
+	else
+		_files
+	fi
+}
+
+# don't run the completion function when being source-ed or eval-ed
+if [ "$funcstack[1]" = "_bsky" ]; then
+	_bsky
+fi

--- a/scripts/powershell_autocomplete.ps1
+++ b/scripts/powershell_autocomplete.ps1
@@ -1,0 +1,9 @@
+$fn = $($MyInvocation.MyCommand.Name)
+$name = $fn -replace "(.*)\.ps1$", '$1'
+Register-ArgumentCompleter -Native -CommandName $name -ScriptBlock {
+     param($commandName, $wordToComplete, $cursorPosition)
+     $other = "$wordToComplete --generate-shell-completion"
+         Invoke-Expression $other | ForEach-Object {
+            [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+         }
+ }


### PR DESCRIPTION
Implement autocomplete functionality for the command-line interface across multiple shell environments, enhancing user experience and efficiency. Include instructions for enabling autocomplete in respective shell configuration files.