### PR TITLE
Typo; wrong if/else order for handling image alt text

### DIFF
--- a/timeline.go
+++ b/timeline.go
@@ -413,9 +413,9 @@ func doPost(cCtx *cli.Context) error {
 			}
 			var alt string
 			if len(imageAltFn) < i {
-				alt = imageAltFn[i]
-			} else {
 				alt = filepath.Base(fn)
+			} else {
+				alt = imageAltFn[i]
 			}
 			images = append(images, &bsky.EmbedImages_Image{
 				Alt: alt,


### PR DESCRIPTION
This caused alt text to get missed when len(imageAltFn) == i, which is the case for a single image.

Introduced in #8, thank you @backspace for the feature!

Spotted by @jix.one, thank you.
https://bsky.app/profile/jix.one/post/3lbrii6tzjs2c

Debugging here:
https://bsky.app/profile/katef.bsky.social/post/3lbqklydtg52b