### PR TITLE
ci: use macos-13 to fix the release asset name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
 
   build_for_macos:
     name: Build for MacOS
-    runs-on: macos-latest
+    runs-on: macos-13 # Use macos-13 to build darwin/amd64. macos-latest is arm64.
     steps:
     - name: Install build dependencies
       run: brew install coreutils


### PR DESCRIPTION
Close #35

Change GitHub Actions Runner from macos-latest (darwin/arm64) to macos-13 (darwin/amd64) to build assets for darwin/amd64 properly.

If GOARCH (amd64) is different from the actual architecture (arm64), `go install` installs a binary in `$HOME/go/bin/{GOOS}_{GOARCH}/{binary}`, not `$HOME/go/bin/{binary}`.

```console
bash-3.2$ go install github.com/x-motemen/gobump/cmd/gobump@latest
bash-3.2$ ls ~/go/bin/
gobump
```

```console
bash-3.2$ GOARCH=amd64 go install github.com/x-motemen/gobump/cmd/gobump@latest
bash-3.2$ ls ~/go/bin/darwin_amd64/
gobump
```

So now `gobump` isn't found when building assets for darwin/amd64. https://github.com/mattn/bsky/issues/35#issuecomment-2499888726

To solve this issue, this pull request changes GitHub Actions Runner from macos-latest (darwin/arm64) to macos-13 (darwin/amd64).

## Test

I've confirmed this pull request would solve the issue.

https://github.com/suzuki-shunsuke/bsky/releases/tag/v0.0.64-2

<img width="463" alt="image" src="https://github.com/user-attachments/assets/4c83b720-bb9d-4617-9a17-98ff810ac5ba">
