### PR TITLE
Fix stream --cursor not being applied to the URL

### DIFF
--- a/timeline.go
+++ b/timeline.go
@@ -683,6 +683,21 @@ func doReposts(cCtx *cli.Context) error {
 	return nil
 }
 
+func streamHost(host, cursor string) (string, error) {
+	u, err := url.Parse(host)
+	if err != nil {
+		return "", err
+	}
+	u.Scheme = "wss"
+	u.Path = "/xrpc/com.atproto.sync.subscribeRepos"
+	if cursor != "" {
+		q := u.Query()
+		q.Set("cursor", cursor)
+		u.RawQuery = q.Encode()
+	}
+	return u.String(), nil
+}
+
 func doStream(cCtx *cli.Context) error {
 	var host string
 	if cCtx.Args().Present() {
@@ -693,17 +708,11 @@ func doStream(cCtx *cli.Context) error {
 		if host == "" {
 			host = cfg.Host
 		}
-		u, err := url.Parse(host)
+		var err error
+		host, err = streamHost(host, cCtx.String("cursor"))
 		if err != nil {
 			return err
 		}
-		u.Scheme = "wss"
-		u.Path = "/xrpc/com.atproto.sync.subscribeRepos"
-		cur := cCtx.String("cursor")
-		if cur != "" {
-			u.Query().Add("cursor", cur)
-		}
-		host = u.String()
 	}
 	pattern := cCtx.String("pattern")
 	reply := cCtx.String("reply")

--- a/timeline_test.go
+++ b/timeline_test.go
@@ -1,0 +1,40 @@
+package main
+
+import "testing"
+
+func TestStreamHost(t *testing.T) {
+	tests := []struct {
+		name   string
+		host   string
+		cursor string
+		want   string
+	}{
+		{
+			name: "without cursor",
+			host: "https://bsky.network",
+			want: "wss://bsky.network/xrpc/com.atproto.sync.subscribeRepos",
+		},
+		{
+			name:   "with cursor",
+			host:   "https://bsky.network",
+			cursor: "123",
+			want:   "wss://bsky.network/xrpc/com.atproto.sync.subscribeRepos?cursor=123",
+		},
+		{
+			name:   "preserve existing query",
+			host:   "https://bsky.network?foo=bar",
+			cursor: "123",
+			want:   "wss://bsky.network/xrpc/com.atproto.sync.subscribeRepos?cursor=123&foo=bar",
+		},
+	}
+
+	for _, tt := range tests {
+		got, err := streamHost(tt.host, tt.cursor)
+		if err != nil {
+			t.Fatalf("%s: streamHost returned error: %v", tt.name, err)
+		}
+		if got != tt.want {
+			t.Fatalf("%s: want %q but got %q", tt.name, tt.want, got)
+		}
+	}
+}


### PR DESCRIPTION
`u.Query()` returns a copy of the query values, so mutating it with `Add` had no effect on the request URL and `--cursor` was silently ignored. Encode the modified query back into `RawQuery`, and extract the host-building logic into `streamHost` so it can be covered by a unit test.