### PR TITLE
Fix nil pointer dereference in addLink when HTML parse fails

### DIFF
--- a/timeline.go
+++ b/timeline.go
@@ -241,6 +241,9 @@ func addLink(xrpcc *xrpc.Client, post *bsky.FeedPost, link string) {
 			},
 		}
 	} else {
+		if post.Embed == nil {
+			post.Embed = &bsky.FeedPost_Embed{}
+		}
 		post.Embed.EmbedExternal = &bsky.EmbedExternal{
 			External: &bsky.EmbedExternal_External{
 				Uri: link,


### PR DESCRIPTION
In the fallback branch where external link card HTML parsing fails, `post.Embed` may still be `nil`, causing a nil pointer dereference when assigning `post.Embed.EmbedExternal`. Initialize `post.Embed` before use.