### PR TITLE
Fix wrong variable in quote post uri error message

### DIFF
--- a/timeline.go
+++ b/timeline.go
@@ -327,7 +327,7 @@ func doPost(cCtx *cli.Context) error {
 	if quoteTo != "" {
 		parts := strings.Split(quoteTo, "/")
 		if len(parts) < 3 {
-			return fmt.Errorf("invalid post uri: %q", replyTo)
+			return fmt.Errorf("invalid post uri: %q", quoteTo)
 		}
 		rkey := parts[len(parts)-1]
 		collection := parts[len(parts)-2]


### PR DESCRIPTION
When validating the quote target uri, the error message printed `replyTo` instead of the `quoteTo` value actually being checked, showing a misleading value to the user.